### PR TITLE
Implement habit endpoints

### DIFF
--- a/ourhabits-backend/controllers/habitController.js
+++ b/ourhabits-backend/controllers/habitController.js
@@ -1,0 +1,73 @@
+const { PrismaClient } = require("@prisma/client");
+const prisma = new PrismaClient();
+
+// Obtener todos los hábitos del usuario autenticado
+exports.getHabits = async (req, res) => {
+  try {
+    const habits = await prisma.habit.findMany({
+      where: { userId: req.user.userId },
+      orderBy: { date: "asc" },
+    });
+    res.json(habits);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Error al obtener hábitos" });
+  }
+};
+
+// Crear un nuevo hábito
+exports.createHabit = async (req, res) => {
+  const { title, points, date } = req.body;
+  if (!title || !points || !date) {
+    return res.status(400).json({ message: "Faltan datos para crear el hábito" });
+  }
+
+  try {
+    const habit = await prisma.habit.create({
+      data: {
+        title,
+        points,
+        date: new Date(date),
+        userId: req.user.userId,
+      },
+    });
+    res.status(201).json(habit);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Error al crear hábito" });
+  }
+};
+
+// Actualizar hábito (marcar completado o modificar datos)
+exports.updateHabit = async (req, res) => {
+  const { id } = req.params;
+  const { title, points, date, completed } = req.body;
+
+  try {
+    const habit = await prisma.habit.update({
+      where: { id: parseInt(id), userId: req.user.userId },
+      data: {
+        ...(title && { title }),
+        ...(points !== undefined && { points }),
+        ...(date && { date: new Date(date) }),
+        ...(completed !== undefined && { completed }),
+      },
+    });
+    res.json(habit);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Error al actualizar hábito" });
+  }
+};
+
+// Eliminar hábito
+exports.deleteHabit = async (req, res) => {
+  const { id } = req.params;
+  try {
+    await prisma.habit.delete({ where: { id: parseInt(id), userId: req.user.userId } });
+    res.status(204).end();
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Error al eliminar hábito" });
+  }
+};

--- a/ourhabits-backend/index.js
+++ b/ourhabits-backend/index.js
@@ -3,6 +3,7 @@ const express = require("express");
 const cors = require("cors");
 const { PrismaClient } = require("@prisma/client");
 const userRoutes = require("./routes/userRoutes");
+const habitRoutes = require("./routes/habitRoutes");
 
 const prisma = new PrismaClient();
 const app = express();
@@ -13,6 +14,7 @@ app.use(express.json());
 
 // Rutas
 app.use("/api/users", userRoutes);
+app.use("/api/habits", habitRoutes);
 
 app.get("/", (req, res) => {
   res.send("✅ OurHabits API funcionando correctamente.");

--- a/ourhabits-backend/routes/habitRoutes.js
+++ b/ourhabits-backend/routes/habitRoutes.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const router = express.Router();
+const habitController = require("../controllers/habitController");
+const authMiddleware = require("../middleware/authMiddleware");
+
+// Proteger todas las rutas con autenticación
+router.use(authMiddleware);
+
+router.get("/", habitController.getHabits);
+router.post("/", habitController.createHabit);
+router.put("/:id", habitController.updateHabit);
+router.delete("/:id", habitController.deleteHabit);
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add controller for habits with CRUD logic
- register /api/habits routes
- wire habit routes in Express app

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6850a68bd4288325923e59992caeb499