### PR TITLE
Implementación de páginas de login y registro

### DIFF
--- a/frontend/login.html
+++ b/frontend/login.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Iniciar sesión - OurHabits</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Iniciar sesión</h1>
+  <form id="loginForm">
+    <label for="email">Correo electrónico:</label>
+    <input type="email" id="email" required>
+    <label for="password">Contraseña:</label>
+    <input type="password" id="password" required>
+    <button type="submit">Ingresar</button>
+  </form>
+  <p>¿No tienes cuenta? <a href="register.html">Regístrate aquí</a></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/register.html
+++ b/frontend/register.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Registro - OurHabits</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Registro</h1>
+  <form id="registerForm">
+    <label for="email">Correo electrónico:</label>
+    <input type="email" id="email" required>
+    <label for="password">Contraseña:</label>
+    <input type="password" id="password" required>
+    <button type="submit">Registrarse</button>
+  </form>
+  <p>¿Ya tienes cuenta? <a href="login.html">Inicia sesión</a></p>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/frontend/script.js
+++ b/frontend/script.js
@@ -1,0 +1,54 @@
+const API_URL = 'http://localhost:3000/api/users';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const loginForm = document.getElementById('loginForm');
+  const registerForm = document.getElementById('registerForm');
+
+  if (loginForm) {
+    loginForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+      try {
+        const res = await fetch(`${API_URL}/login`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+        const data = await res.json();
+        if (res.ok) {
+          localStorage.setItem('token', data.token);
+          alert('Inicio de sesión exitoso');
+        } else {
+          alert(data.message || 'Error al iniciar sesión');
+        }
+      } catch (err) {
+        alert('Error de conexión');
+      }
+    });
+  }
+
+  if (registerForm) {
+    registerForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = document.getElementById('email').value;
+      const password = document.getElementById('password').value;
+      try {
+        const res = await fetch(`${API_URL}/register`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, password })
+        });
+        const data = await res.json();
+        if (res.ok) {
+          alert('Usuario registrado con éxito');
+          window.location.href = 'login.html';
+        } else {
+          alert(data.message || 'Error al registrarse');
+        }
+      } catch (err) {
+        alert('Error de conexión');
+      }
+    });
+  }
+});

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -1,0 +1,22 @@
+body {
+  font-family: Arial, sans-serif;
+  max-width: 400px;
+  margin: 40px auto;
+  padding: 20px;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+}
+label {
+  display: block;
+  margin-top: 10px;
+}
+input {
+  width: 100%;
+  padding: 8px;
+  margin-top: 5px;
+  box-sizing: border-box;
+}
+button {
+  margin-top: 15px;
+  padding: 10px 15px;
+}


### PR DESCRIPTION
## Resumen
- se añadió una carpeta `frontend` con páginas estáticas
- se crearon `login.html` y `register.html` para autenticación
- se incluyeron `styles.css` y `script.js` para el manejo de formularios

## Testing
- `npm test` (sin pruebas definidas, devuelve mensaje de error)


------
https://chatgpt.com/codex/tasks/task_e_6850a8a052e88325af0710911be6961f