### PR TITLE
Add simple React login form

### DIFF
--- a/ourhabits-frontend/.env.example
+++ b/ourhabits-frontend/.env.example
@@ -1,0 +1,2 @@
+# URL base de la API del backend
+VITE_API_BASE_URL=http://localhost:3000

--- a/ourhabits-frontend/README.md
+++ b/ourhabits-frontend/README.md
@@ -1,12 +1,20 @@
-# React + Vite
+# OurHabits Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Este frontend utiliza React y Vite. Contiene un sencillo formulario de registro e inicio de sesión que se comunica con el backend de OurHabits.
 
-Currently, two official plugins are available:
+## Variables de entorno
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+Copia el archivo `.env.example` a `.env` y ajusta `VITE_API_BASE_URL` con la URL base de tu backend (por defecto `http://localhost:3000`).
 
-## Expanding the ESLint configuration
+```bash
+cp .env.example .env
+```
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+## Scripts
+
+- `npm run dev` &mdash; ejecuta la aplicación en modo desarrollo.
+- `npm run build` &mdash; genera la versión de producción.
+
+## Despliegue por túnel Cloudflare
+
+Si expones tu backend local mediante un túnel de Cloudflare (por ejemplo `ourhabits.org`), asegúrate de que `VITE_API_BASE_URL` apunte a ese dominio para que el frontend pueda acceder desde cualquier lugar.

--- a/ourhabits-frontend/src/App.css
+++ b/ourhabits-frontend/src/App.css
@@ -1,42 +1,45 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f5f5f5;
+}
+
+.container {
+  max-width: 400px;
+  margin: 2rem auto;
   padding: 2rem;
+  background: white;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+.form input {
+  padding: 0.5rem;
+  font-size: 1rem;
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+.form button {
+  padding: 0.5rem 1rem;
+  font-size: 1rem;
+  cursor: pointer;
 }
 
-.card {
-  padding: 2em;
+.toggle {
+  margin-top: 1rem;
+  background: none;
+  border: none;
+  color: #007bff;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
-.read-the-docs {
-  color: #888;
+.message {
+  margin-top: 1rem;
+  color: green;
 }

--- a/ourhabits-frontend/src/App.jsx
+++ b/ourhabits-frontend/src/App.jsx
@@ -1,34 +1,56 @@
 import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
+import { loginRequest, registerRequest } from './api'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isRegister, setIsRegister] = useState(false)
+  const [message, setMessage] = useState('')
+
+  const handleSubmit = async (e) => {
+    e.preventDefault()
+    setMessage('')
+    try {
+      if (isRegister) {
+        await registerRequest(email, password)
+        setMessage('Registro exitoso, ahora puedes iniciar sesión.')
+        setIsRegister(false)
+      } else {
+        const data = await loginRequest(email, password)
+        localStorage.setItem('token', data.token)
+        setMessage('Sesión iniciada correctamente.')
+      }
+    } catch (err) {
+      setMessage(err.message)
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.jsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="container">
+      <h1>{isRegister ? 'Registro' : 'Login'}</h1>
+      <form onSubmit={handleSubmit} className="form">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Contraseña"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit">{isRegister ? 'Registrarse' : 'Iniciar sesión'}</button>
+      </form>
+      <button className="toggle" onClick={() => setIsRegister(!isRegister)}>
+        {isRegister ? '¿Ya tienes cuenta? Inicia sesión' : '¿No tienes cuenta? Regístrate'}
+      </button>
+      {message && <p className="message">{message}</p>}
+    </div>
   )
 }
 

--- a/ourhabits-frontend/src/api.js
+++ b/ourhabits-frontend/src/api.js
@@ -1,0 +1,35 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+
+export async function loginRequest(email, password) {
+  const response = await fetch(`${API_BASE_URL}/api/users/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ email, password })
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.message || 'Error al iniciar sesión');
+  }
+
+  return response.json();
+}
+
+export async function registerRequest(email, password) {
+  const response = await fetch(`${API_BASE_URL}/api/users/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ email, password })
+  });
+
+  if (!response.ok) {
+    const data = await response.json().catch(() => ({}));
+    throw new Error(data.message || 'Error al registrar');
+  }
+
+  return response.json();
+}


### PR DESCRIPTION
## Summary
- implement login and register requests in `api.js`
- replace example React component with a login/registration form
- add basic styles for the form
- document environment variable usage for Cloudflare tunnel
- provide `.env.example`

## Testing
- `npm run lint` (frontend)
- `npm test` (backend, expected failure: no tests specified)


------
https://chatgpt.com/codex/tasks/task_e_6850aadd0f748325a228e6498ca0cf7d