### PR TITLE
Actualiza config de Cloudflare y README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# OurHabits
+
+Este repositorio contiene la configuración y el código para los proyectos **OurHabits**.
+
+## Configuración del túnel de Cloudflare
+
+El archivo `config.yml` define el túnel de Cloudflare utilizado para exponer el backend.
+Para indicar dónde se encuentra el archivo de credenciales puedes definir la variable de
+entorno `CLOUDFLARED_CREDENTIALS_FILE`:
+
+```bash
+export CLOUDFLARED_CREDENTIALS_FILE=~/.cloudflared/cred.json
+```
+
+Si no defines la variable, `config.yml` utilizará la ruta `~/.cloudflared/cred.json` por defecto.
+
+Guarda el archivo de credenciales de tu túnel de Cloudflare en esa ubicación o ajusta la
+variable de entorno antes de ejecutar `cloudflared`.

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,8 @@
 tunnel: e1da5b3b-f275-4fc0-a865-097aea9849e1
-credentials-file: C:\Users\luisi\.cloudflared\e1da5b3b-f275-4fc0-a865-097aea9849e1.json
+# La ubicación del archivo de credenciales puede establecerse mediante la
+# variable de entorno `CLOUDFLARED_CREDENTIALS_FILE` o caer por defecto en la
+# ruta `~/.cloudflared/cred.json`.
+credentials-file: ${CLOUDFLARED_CREDENTIALS_FILE:-~/.cloudflared/cred.json}
 
 ingress:
   - hostname: ourhabits.org


### PR DESCRIPTION
## Summary
- permite definir la ruta del archivo de credenciales con la variable de entorno `CLOUDFLARED_CREDENTIALS_FILE`
- crea README con instrucciones para usar dicha variable

## Testing
- `npm test` en `ourhabits-backend`
- `npm test` en `ourhabits-frontend` *(falla: script faltante)*

------
https://chatgpt.com/codex/tasks/task_e_68512be1fae883259100f0e5c7c1cc3d