### PR TITLE
Add backend env example and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,25 @@
 # OurHabits
 
-
-Este repositorio contiene el frontend y el backend de **OurHabits**.
+Este repositorio incluye tanto el _backend_ como el _frontend_ de **OurHabits**.
 
 ## Ejecutar pruebas
 
-1. Instala las dependencias en la carpeta del backend:
+1. Instala las dependencias en `ourhabits-backend`:
+   ```bash
+   cd ourhabits-backend
+   npm install
+   ```
+2. Lanza los tests con:
+   ```bash
+   npm test
+   ```
 
-```bash
-cd ourhabits-backend
-npm install
-```
-
-2. Ejecuta las pruebas con:
-
-```bash
-npm test
-```
-
-Esto lanzará Jest y mostrará el resultado de los tests definidos en `__tests__`.
-=======
-Este repositorio contiene dos aplicaciones separadas:
-
-- **ourhabits-backend**: API REST construida con Node.js, Express y Prisma para gestionar hábitos y usuarios.
-- **ourhabits-frontend**: interfaz web creada con React y Vite que consume la API anterior.
-
-## Instalación de dependencias
+## Instalación y desarrollo
 
 ### Backend
 1. `cd ourhabits-backend`
 2. `npm install`
-3. Define un archivo `.env` con las variables necesarias (`DATABASE_URL`, `JWT_SECRET`, etc.).
+3. Copia `.env.example` a `.env` y ajusta las variables (`DATABASE_URL`, `JWT_SECRET`, etc.).
 4. Ejecuta las migraciones de Prisma:
    ```bash
    npx prisma migrate dev
@@ -43,36 +32,20 @@ Este repositorio contiene dos aplicaciones separadas:
 ### Frontend
 1. `cd ourhabits-frontend`
 2. `npm install`
-3. Copia `.env.example` a `.env` y ajusta `VITE_API_BASE_URL` con la URL de tu backend.
-4. Lanza la aplicación de desarrollo:
+3. Copia `.env.example` a `.env` y actualiza `VITE_API_BASE_URL` según corresponda.
+4. Ejecuta en modo desarrollo:
    ```bash
    npm run dev
    ```
 
 ## Acceso mediante Cloudflare Tunnel
 
-El archivo `config.yml` permite exponer el backend a internet usando Cloudflare. Para habilitarlo, instala `cloudflared` y ejecuta:
-
+El archivo `config.yml` permite exponer el backend usando Cloudflare. Instala `cloudflared` y ejecuta:
 ```bash
 cloudflared tunnel --config config.yml run
 ```
-
-Una vez activo el túnel, actualiza `VITE_API_BASE_URL` en el frontend para que apunte al dominio público definido en `config.yml`.
-
-=======
-Este repositorio contiene la configuración y el código para los proyectos **OurHabits**.
+Luego actualiza `VITE_API_BASE_URL` en el frontend para apuntar al dominio público.
 
 ## Configuración del túnel de Cloudflare
 
-El archivo `config.yml` define el túnel de Cloudflare utilizado para exponer el backend.
-Para indicar dónde se encuentra el archivo de credenciales puedes definir la variable de
-entorno `CLOUDFLARED_CREDENTIALS_FILE`:
-
-```bash
-export CLOUDFLARED_CREDENTIALS_FILE=~/.cloudflared/cred.json
-```
-
-Si no defines la variable, `config.yml` utilizará la ruta `~/.cloudflared/cred.json` por defecto.
-
-Guarda el archivo de credenciales de tu túnel de Cloudflare en esa ubicación o ajusta la
-variable de entorno antes de ejecutar `cloudflared`.
+Si tus credenciales no están en `~/.cloudflared/cred.json`, define la variable de entorno `CLOUDFLARED_CREDENTIALS_FILE` con la ruta correcta antes de lanzar `cloudflared`.

--- a/ourhabits-backend/.env.example
+++ b/ourhabits-backend/.env.example
@@ -1,0 +1,6 @@
+# Configuración de la base de datos
+# Usa una URL de PostgreSQL o SQLite. Ejemplo para SQLite:
+DATABASE_URL="file:./dev.db"
+
+# Clave secreta para JWT
+JWT_SECRET=secretdev123


### PR DESCRIPTION
## Summary
- add `.env.example` with database and JWT config for backend
- clean up and update README instructions

## Testing
- `npm test` in `ourhabits-backend`
- `npm run lint` in `ourhabits-frontend`


------
https://chatgpt.com/codex/tasks/task_e_68512eeef33883258f3979a3ce274c91